### PR TITLE
Fix encoded writer bit sizing writer.uint32(18) => writer.uint32(10).

### DIFF
--- a/packages/sdk/src/compatability/queryHelper.ts
+++ b/packages/sdk/src/compatability/queryHelper.ts
@@ -19,7 +19,7 @@ export function encodeInputQueryWithPagination<T extends { pagination?: PageRequ
   writer: _m0.Writer = _m0.Writer.create()
 ): _m0.Writer {
   if (message.pagination !== undefined) {
-    PageRequest.encode(message.pagination, writer.uint32(18).fork()).ldelim();
+    PageRequest.encode(message.pagination, writer.uint32(10).fork()).ldelim();
   }
   return writer;
 }


### PR DESCRIPTION
Fix encoded writer bit sizing writer.uint32(18) => writer.uint32(10).
PageRequest.encode(message.pagination, writer.uint32(10).fork()).ldelim();